### PR TITLE
Update game_of_life.c

### DIFF
--- a/applications/game_of_life/game_of_life.c
+++ b/applications/game_of_life/game_of_life.c
@@ -136,7 +136,8 @@ int32_t game_of_life_app(void* p) {
             if(event.input.key == InputKeyBack) {
                 // furiac_exit(NULL);
                 processing = false;
-                return 0;
+                release_mutex(&state_mutex, state);
+                break;
             }
         }
 


### PR DESCRIPTION
This fixes the hard fault but also reveals another issue with the code - there is no logic to free the memory resources allocated for the playfield state, so quitting and then relaunching the game just continues the old one, rather than starting from scratch. Unsure how much RAM this is eating up when the game is not running :/

# What's new

- **breaking** out of the loop instead of **returning 0**, so that the open resources can be terminated/freed gracefully
- releasing the **state_mutex** as this is skipped when breaking out of the loop. If the state_mutex is not released then the app cannot be reopened after terminating

# Verification 

- Recompile firmware and stick it on ur flippy

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
