### PR TITLE
New LFRFID Mode/Feature

### DIFF
--- a/applications/lfrfid/lfrfid_app.cpp
+++ b/applications/lfrfid/lfrfid_app.cpp
@@ -20,6 +20,8 @@
 #include "scene/lfrfid_app_scene_saved_info.h"
 #include "scene/lfrfid_app_scene_delete_confirm.h"
 #include "scene/lfrfid_app_scene_delete_success.h"
+#include "scene/lfrfid_app_scene_emu_menu.h"
+#include "scene/lfrfid_app_scene_emu_data.h"
 
 #include <toolbox/path.h>
 #include <flipper_format/flipper_format.h>
@@ -70,6 +72,8 @@ void LfRfidApp::run(void* _args) {
         scene_controller.add_scene(SceneType::SavedInfo, new LfRfidAppSceneSavedInfo());
         scene_controller.add_scene(SceneType::DeleteConfirm, new LfRfidAppSceneDeleteConfirm());
         scene_controller.add_scene(SceneType::DeleteSuccess, new LfRfidAppSceneDeleteSuccess());
+        scene_controller.add_scene(SceneType::EmuMenu, new LfRfidAppSceneEmuMenu());
+        scene_controller.add_scene(SceneType::EmuData, new LfRfidAppSceneEmuData());
         scene_controller.process(100);
     }
 }

--- a/applications/lfrfid/lfrfid_app.h
+++ b/applications/lfrfid/lfrfid_app.h
@@ -51,6 +51,8 @@ public:
         SavedInfo,
         DeleteConfirm,
         DeleteSuccess,
+        EmuMenu,
+        EmuData,
     };
 
     class Event {

--- a/applications/lfrfid/scene/lfrfid_app_scene_emu_data.cpp
+++ b/applications/lfrfid/scene/lfrfid_app_scene_emu_data.cpp
@@ -1,0 +1,37 @@
+#include "lfrfid_app_scene_emu_data.h"
+#include <dolphin/dolphin.h>
+
+void LfRfidAppSceneEmuData::on_enter(LfRfidApp* app, bool /*need_restore*/) {
+    auto byte_input = app->view_controller.get<ByteInputVM>();
+
+    byte_input->set_header_text("Enter the data in hex");
+
+    byte_input->set_result_callback(
+        save_callback, NULL, app, key_data, app->worker.key.get_type_data_count());
+
+    app->view_controller.switch_to<ByteInputVM>();
+}
+
+bool LfRfidAppSceneEmuData::on_event(LfRfidApp* app, LfRfidApp::Event* event) {
+    bool consumed = false;
+    RfidKey& key = app->worker.key;
+
+    if(event->type == LfRfidApp::EventType::Next) {
+        key.set_data(key_data, key.get_type_data_count());
+        DOLPHIN_DEED(DolphinDeedRfidAdd);
+        app->scene_controller.switch_to_next_scene(LfRfidApp::SceneType::Emulate);
+    }
+
+    return consumed;
+}
+
+void LfRfidAppSceneEmuData::on_exit(LfRfidApp* app) {
+    app->view_controller.get<ByteInputVM>()->clean();
+}
+
+void LfRfidAppSceneEmuData::save_callback(void* context) {
+    LfRfidApp* app = static_cast<LfRfidApp*>(context);
+    LfRfidApp::Event event;
+    event.type = LfRfidApp::EventType::Next;
+    app->view_controller.send_event(&event);
+}

--- a/applications/lfrfid/scene/lfrfid_app_scene_emu_data.h
+++ b/applications/lfrfid/scene/lfrfid_app_scene_emu_data.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "../lfrfid_app.h"
+
+class LfRfidAppSceneEmuData : public GenericScene<LfRfidApp> {
+public:
+    void on_enter(LfRfidApp* app, bool /*need_restore*/) final;
+    bool on_event(LfRfidApp* app, LfRfidApp::Event* event) final;
+    void on_exit(LfRfidApp* app) final;
+
+private:
+    static void save_callback(void* context);
+
+    uint8_t key_data[LFRFID_KEY_SIZE] = {
+        0xBB,
+        0xBB,
+        0xBB,
+        0xBB,
+        0xBB,
+        0xBB,
+        0xBB,
+        0xBB,
+    };
+};

--- a/applications/lfrfid/scene/lfrfid_app_scene_emu_menu.cpp
+++ b/applications/lfrfid/scene/lfrfid_app_scene_emu_menu.cpp
@@ -1,0 +1,53 @@
+#include "lfrfid_app_scene_emu_menu.h"
+
+void LfRfidAppSceneEmuMenu::on_enter(LfRfidApp* app, bool need_restore) {
+    auto submenu = app->view_controller.get<SubmenuVM>();
+
+    for(uint8_t i = 0; i <= keys_count; i++) {
+        string_init_printf(
+            submenu_name[i],
+            "%s %s",
+            lfrfid_key_get_manufacturer_string(static_cast<LfrfidKeyType>(i)),
+            lfrfid_key_get_type_string(static_cast<LfrfidKeyType>(i)));
+        submenu->add_item(string_get_cstr(submenu_name[i]), i, submenu_callback, app);
+    }
+
+    if(need_restore) {
+        submenu->set_selected_item(submenu_item_selected);
+    }
+
+    app->view_controller.switch_to<SubmenuVM>();
+
+    // clear key name
+    app->worker.key.set_name("");
+}
+
+bool LfRfidAppSceneEmuMenu::on_event(LfRfidApp* app, LfRfidApp::Event* event) {
+    bool consumed = false;
+
+    if(event->type == LfRfidApp::EventType::MenuSelected) {
+        submenu_item_selected = event->payload.menu_index;
+        app->worker.key.set_type(static_cast<LfrfidKeyType>(event->payload.menu_index));
+        app->scene_controller.switch_to_next_scene(LfRfidApp::SceneType::EmuData); // edit here
+        consumed = true;
+    }
+
+    return consumed;
+}
+
+void LfRfidAppSceneEmuMenu::on_exit(LfRfidApp* app) {
+    app->view_controller.get<SubmenuVM>()->clean();
+    for(uint8_t i = 0; i <= keys_count; i++) {
+        string_clear(submenu_name[i]);
+    }
+}
+
+void LfRfidAppSceneEmuMenu::submenu_callback(void* context, uint32_t index) {
+    LfRfidApp* app = static_cast<LfRfidApp*>(context);
+    LfRfidApp::Event event;
+
+    event.type = LfRfidApp::EventType::MenuSelected;
+    event.payload.menu_index = index;
+
+    app->view_controller.send_event(&event);
+}

--- a/applications/lfrfid/scene/lfrfid_app_scene_emu_menu.h
+++ b/applications/lfrfid/scene/lfrfid_app_scene_emu_menu.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "../lfrfid_app.h"
+
+class LfRfidAppSceneEmuMenu : public GenericScene<LfRfidApp> {
+public:
+    void on_enter(LfRfidApp* app, bool need_restore) final;
+    bool on_event(LfRfidApp* app, LfRfidApp::Event* event) final;
+    void on_exit(LfRfidApp* app) final;
+
+private:
+    static void submenu_callback(void* context, uint32_t index);
+    uint32_t submenu_item_selected = 0;
+    static const uint8_t keys_count = static_cast<uint8_t>(LfrfidKeyType::KeyIoProxXSF);
+    string_t submenu_name[keys_count + 1];
+};

--- a/applications/lfrfid/scene/lfrfid_app_scene_start.cpp
+++ b/applications/lfrfid/scene/lfrfid_app_scene_start.cpp
@@ -4,6 +4,7 @@ typedef enum {
     SubmenuRead,
     SubmenuSaved,
     SubmenuAddManually,
+    SubMenuEmulateDirectly,
 } SubmenuIndex;
 
 void LfRfidAppSceneStart::on_enter(LfRfidApp* app, bool need_restore) {
@@ -12,6 +13,7 @@ void LfRfidAppSceneStart::on_enter(LfRfidApp* app, bool need_restore) {
     submenu->add_item("Read", SubmenuRead, submenu_callback, app);
     submenu->add_item("Saved", SubmenuSaved, submenu_callback, app);
     submenu->add_item("Add Manually", SubmenuAddManually, submenu_callback, app);
+    submenu->add_item("Emulate Directly", SubMenuEmulateDirectly, submenu_callback, app);
 
     if(need_restore) {
         submenu->set_selected_item(submenu_item_selected);
@@ -37,6 +39,9 @@ bool LfRfidAppSceneStart::on_event(LfRfidApp* app, LfRfidApp::Event* event) {
             break;
         case SubmenuAddManually:
             app->scene_controller.switch_to_next_scene(LfRfidApp::SceneType::SaveType);
+            break;
+        case SubMenuEmulateDirectly:
+            app->scene_controller.switch_to_next_scene(LfRfidApp::SceneType::EmuMenu);
             break;
         }
         consumed = true;


### PR DESCRIPTION
# What's new

- Created some new scenes in applications/lfrfid/scenes
- - lfrfid_app_scene_emu_data
- - lfrfid_app_scene_emu_menu
- Also updated some core files to enumerate the new scenes

# Verification 

- Recompile the firmware and load it on ur flippy
- Check "125 kHz RFID" application for a 4th menu item - **Emulate Directly**
- Select encoding
- Enter hex digits and hit "save"
- Flippy should now be emulating the digits u entered
- Hitting back will take u back to byte edit screen

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
